### PR TITLE
Added on/off support for the Toon

### DIFF
--- a/toon_climate/climate.py
+++ b/toon_climate/climate.py
@@ -100,7 +100,7 @@ class ThermostatDevice(ClimateDevice):
         self._current_setpoint = int(self._data['currentSetpoint'])/100
         self._current_temp = int(self._data['currentTemp'])/100
         self._current_state = int(self._data['activeState'])
-        self._is_on = int(self._data['programState'])
+        self._is_on = 0 if int(self._data['nextState']) == -1 else 1
         _LOGGER.debug("Update called")
 
     @property


### PR DESCRIPTION
You can now toggle the Toon's heating program and you are able to get the current state of the program. This is handy during summers where you might want to disable the heating function of the Toon.

Tested on my own HASS (v0.94.1) installation.